### PR TITLE
Features in @Entity and @Flush. Solves #11 #7

### DIFF
--- a/Annotation/Entity.php
+++ b/Annotation/Entity.php
@@ -44,6 +44,20 @@ class Entity extends Annotation
     public $setters = array();
 
     /**
+     * @var string
+     *
+     * Manager to use when persisting
+     */
+    public $manager;
+
+    /**
+     * @var boolean
+     *
+     * Persist entity
+     */
+    public $persist;
+
+    /**
      * return class
      *
      * @return string Class
@@ -71,5 +85,25 @@ class Entity extends Annotation
     public function getSetters()
     {
         return $this->setters;
+    }
+
+    /**
+     * return manager
+     *
+     * @return string Manager
+     */
+    public function getManager()
+    {
+        return $this->manager;
+    }
+
+    /**
+     * return persist
+     *
+     * @return boolean persist
+     */
+    public function getPersist()
+    {
+        return $this->persist;
     }
 }

--- a/Annotation/Flush.php
+++ b/Annotation/Flush.php
@@ -30,6 +30,13 @@ class Flush extends Annotation
     public $manager;
 
     /**
+     * @var entity
+     *
+     * Entity from Request ParameterBag to flush
+     */
+    public $entity;
+
+    /**
      * return manager
      *
      * @return string Manager
@@ -37,5 +44,15 @@ class Flush extends Annotation
     public function getManager()
     {
         return $this->manager;
+    }
+
+    /**
+     * return entity
+     *
+     * @return string Entity
+     */
+    public function getEntity()
+    {
+        return $this->entity;
     }
 }

--- a/Annotation/Form.php
+++ b/Annotation/Form.php
@@ -39,7 +39,7 @@ class Form extends Annotation
     /**
      * @var entity
      *
-     * Entity from paramconverter process to use where building form
+     * Entity from Request ParameterBag to use where building form
      */
     public $entity;
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -81,6 +81,12 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('default_name')
                             ->defaultValue('entity')
                         ->end()
+                        ->scalarNode('default_manager')
+                            ->defaultValue('default')
+                        ->end()
+                        ->scalarNode('default_persist')
+                            ->defaultTrue()
+                        ->end()
                     ->end()
                 ->end()
 

--- a/DependencyInjection/ControllerExtraExtension.php
+++ b/DependencyInjection/ControllerExtraExtension.php
@@ -52,6 +52,8 @@ class ControllerExtraExtension extends Extension
          */
         $container->setParameter('mmoreram.controllerextra.entity_active', $config['entity']['active']);
         $container->setParameter('mmoreram.controllerextra.entity_default_name', $config['entity']['default_name']);
+        $container->setParameter('mmoreram.controllerextra.entity_default_manager', $config['entity']['default_manager']);
+        $container->setParameter('mmoreram.controllerextra.entity_default_persist', $config['entity']['default_persist']);
 
         /**
          * Log parameters

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ controller_extra:
     entity:
         active: true
         default_name: entity
+        default_manager: default
+        default_persist: true
     log:
         active: true
         default_level: info
@@ -170,6 +172,42 @@ public function indexAction(Address $address, User $user)
 
 When `User` instance is built, method `setAddress` is called using as parameter
 the new `Address` instance.
+
+New entities are just created with a simple `new()`, so they are not persisted.
+By default, they will be persisted using `default` manager, but you can disable
+this feature using `persist` option.
+
+You can also change manager using `manager` option.
+
+``` php
+<?php
+
+use Mmoreram\ControllerExtraBundle\Annotation\Entity;
+use Mmoreram\ControllerExtraBundle\Entity\User;
+
+/**
+ * Simple controller method
+ *
+ * @Entiy(
+ *      class = "MmoreramCustomBundle:User",
+ *      name  = "user",
+ *      persist = false,
+ *      manager = 'my_own_manager'
+ * )
+ */
+public function indexAction(User $user)
+{
+}
+```
+
+If you want to change default manager in all annotation instances, you should
+overwrite bundle parameter.
+
+``` yml
+controller_extra:
+    entity:
+        default_manager: my_own_manager
+```
 
 
 ## @Form
@@ -258,8 +296,10 @@ entity using `entity` parameter.
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
-use Mmoreram\ControllerExtraBundle\Annotation\Form as AnnotationForm;
 use Symfony\Component\Form\Form;
+
+use Mmoreram\ControllerExtraBundle\Annotation\Form as AnnotationForm;
+use Mmoreram\ControllerExtraBundle\Entity\User;
 
 /**
  * Simple controller method
@@ -289,8 +329,10 @@ this value is set to `false`
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
-use Mmoreram\ControllerExtraBundle\Annotation\Form as AnnotationForm;
 use Symfony\Component\Form\Form;
+
+use Mmoreram\ControllerExtraBundle\Annotation\Form as AnnotationForm;
+use Mmoreram\ControllerExtraBundle\Entity\User;
 
 /**
  * Simple controller method
@@ -321,8 +363,10 @@ argument.
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
-use Mmoreram\ControllerExtraBundle\Annotation\Form as AnnotationForm;
 use Symfony\Component\Form\Form;
+
+use Mmoreram\ControllerExtraBundle\Annotation\Form as AnnotationForm;
+use Mmoreram\ControllerExtraBundle\Entity\User;
 
 /**
  * Simple controller method
@@ -350,8 +394,9 @@ To inject a FormView object you only need to cast method variable as such.
 ``` php
 <?php
 
-use Mmoreram\ControllerExtraBundle\Annotation\Form;
 use Symfony\Component\Form\FormView;
+
+use Mmoreram\ControllerExtraBundle\Annotation\Form;
 
 /**
  * Simple controller method
@@ -407,10 +452,70 @@ use Mmoreram\ControllerExtraBundle\Annotation\Flush;
  * Simple controller method
  *
  * @Flush(
- *      manager = "my_customer_manager"
+ *      manager = "my_own_manager"
  * )
  */
 public function indexAction()
+{
+}
+```
+
+If you want to change default manager in all annotation instances, you should
+overwrite bundle parameter.
+
+``` yml
+controller_extra:
+    flush:
+        default_manager: my_own_manager
+
+If any parameter is set, annotation will flush all. If you only need to flush
+one or many entities, you can define explicitly which entity must be flushed.
+
+``` php
+<?php
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+
+use Mmoreram\ControllerExtraBundle\Annotation\Flush;
+use Mmoreram\ControllerExtraBundle\Entity\User;
+
+/**
+ * Simple controller method
+ *
+ * @ParamConverter("user", class="MmoreramCustomBundle:User")
+ * @Flush(
+ *      entity = "user"
+ * )
+ */
+public function indexAction(User $user)
+{
+}
+```
+
+You can also define a set of entities to flush
+
+``` php
+<?php
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+
+use Mmoreram\ControllerExtraBundle\Annotation\Flush;
+use Mmoreram\ControllerExtraBundle\Entity\Address;
+use Mmoreram\ControllerExtraBundle\Entity\User;
+
+/**
+ * Simple controller method
+ *
+ * @ParamConverter("user", class="MmoreramCustomBundle:User")
+ * @ParamConverter("address", class="MmoreramCustomBundle:Address")
+ * @Flush(
+ *      entity = {
+ *          "user", 
+ *          "address"
+ *      }
+ * )
+ */
+public function indexAction(User $user, Address $address)
 {
 }
 ```

--- a/Resources/config/resolver_entity.yml
+++ b/Resources/config/resolver_entity.yml
@@ -13,7 +13,9 @@ services:
     mmoreram.controllerextra.resolvers.entity_annotation_resolver:
         class: %mmoreram.controllerextra.resolvers.entity_annotation_resolver.class%
         arguments:
+            doctrine: @doctrine
             bundles: @=service("kernel").getBundles()
             default_name: %mmoreram.controllerextra.form_default_name%
+            default_persist: %mmoreram.controllerextra.entity_default_persist%
         tags:
             - { name: controller_extra.annotation }

--- a/Resources/config/resolver_flush.yml
+++ b/Resources/config/resolver_flush.yml
@@ -14,8 +14,7 @@ services:
         class: %mmoreram.controllerextra.resolvers.flush_annotation_resolver.class%
         arguments:
             doctrine: @doctrine
-        calls:
-            - [setDefaultManager, [%mmoreram.controllerextra.flush_default_manager%]]
+            default_manager: %mmoreram.controllerextra.flush_default_manager%
         tags:
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }
             - { name: controller_extra.annotation }

--- a/Tests/FakeBundle/Controller/FakeController.php
+++ b/Tests/FakeBundle/Controller/FakeController.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of the Controller Extra Bundle
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @since 2013
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mmoreram\ControllerExtraBundle\Tests\FakeBundle\Controller;
+
+use Mmoreram\ControllerExtraBundle\Annotation\Entity;
+use Mmoreram\ControllerExtraBundle\Tests\FakeBundle\Entity\FakeEntity;
+
+/**
+ * Fake Controller object
+ */
+class FakeController
+{
+
+    /**
+     * Public method
+     *
+     * @Entity(
+     *      class = "FakeBundle:FakeEntity",
+     *      name = "entityName"
+     * )
+     * @Entity(
+     *      class = "FakeBundle:FakeEntity"
+     * )
+     */
+    public function entityMethod()
+    {
+
+    }
+}

--- a/Tests/Functional/EntityFunctionalTest.php
+++ b/Tests/Functional/EntityFunctionalTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * This file is part of the Controller Extra Bundle
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @since 2013
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mmoreram\ControllerExtraBundle\Tests\Functional;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpFoundation\Request;
+
+use Mmoreram\ControllerExtraBundle\Tests\FakeBundle\Controller\FakeController;
+use Mmoreram\ControllerExtraBundle\EventListener\ResolverEventListener;
+use Mmoreram\ControllerExtraBundle\Resolver\EntityAnnotationResolver;
+
+/**
+ * Tests FlushAnnotationResolver class
+ */
+class EntityFunctionalTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * Trying entity annotation
+     */
+    public function testFunctionalEntityAnnotation()
+    {
+
+        AnnotationRegistry::registerFile(dirname(__FILE__) . '/../../Annotation/Entity.php');
+
+        $bundle = $this
+            ->getMockBuilder('Symfony\Component\HttpKernel\Bundle\Bundle')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getNamespace'))
+            ->getMock();
+
+        $bundle
+            ->expects($this->any())
+            ->method('getNamespace')
+            ->will($this->returnValue('Mmoreram\ControllerExtraBundle\Tests\FakeBundle'));
+
+        $kernelBundles = array(
+            'FakeBundle'    =>  $bundle
+        );
+
+        $doctrine = $this->getMock('Symfony\Bridge\Doctrine\ManagerRegistry');
+
+        $doctrine = $this
+            ->getMockBuilder('Doctrine\Common\Persistence\AbstractManagerRegistry')
+            ->disableOriginalConstructor()
+            ->setMethods(array(
+                'getService',
+                'resetService',
+                'getContainer',
+                'getAliasNamespace',
+            ))
+            ->getMock();
+
+        $entityAnnotationResolver = new EntityAnnotationResolver($doctrine, $kernelBundles, 'entity', 'default', false);
+        $kernel  = $this->getMock('Symfony\Component\HttpKernel\KernelInterface');
+        $request = new Request();
+        $reader = new AnnotationReader();
+        $event = new FilterControllerEvent($kernel, array(new FakeController(), 'entityMethod'), $request, null);
+        $resolverEventListener = new ResolverEventListener($kernel, $reader);
+        $resolverEventListener->addResolver($entityAnnotationResolver);
+        $resolverEventListener->onKernelController($event);
+
+        $this->assertInstanceOf(
+            'Mmoreram\ControllerExtraBundle\Tests\FakeBundle\Entity\FakeEntity',
+            $request->attributes->get('entityName')
+        );
+
+        $this->assertInstanceOf(
+            'Mmoreram\ControllerExtraBundle\Tests\FakeBundle\Entity\FakeEntity',
+            $request->attributes->get('entity')
+        );
+    }
+}

--- a/Tests/Resolver/FlushAnnotationResolverTest.php
+++ b/Tests/Resolver/FlushAnnotationResolverTest.php
@@ -12,11 +12,21 @@
 
 namespace Mmoreram\ControllerExtraBundle\Tests\Resolver;
 
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Doctrine\Common\Collections\ArrayCollection;
+
 /**
  * Tests FlushAnnotationResolver class
  */
 class FlushAnnotationResolverTest extends \PHPUnit_Framework_TestCase
 {
+
+    /**
+     * @var FlushAnnotationResolver
+     *
+     * Flush Annotation Resolver
+     */
+    private $flushAnnotationResolver;
 
     /**
      * @var Request
@@ -37,10 +47,49 @@ class FlushAnnotationResolverTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
+        $this->flushAnnotationResolver = $this
+            ->getMockBuilder('Mmoreram\ControllerExtraBundle\Resolver\FlushAnnotationResolver')
+            ->disableOriginalConstructor()
+            ->setMethods(array(
+                'getDoctrine',
+                'getDefaultManager',
+            ))
+            ->getMock();
+
+        $manager = $this
+            ->getMockBuilder('Doctrine\ORM\EntityManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $doctrine = $this
+            ->getMockBuilder('Symfony\Bridge\Doctrine\ManagerRegistry')
+            ->disableOriginalConstructor()
+            ->setMethods(array(
+                'getManager',
+            ))
+            ->getMock();
+
+        $doctrine
+            ->expects($this->any())
+            ->method('getManager')
+            ->will($this->returnValue($manager));
+
+        $this->flushAnnotationResolver
+            ->expects($this->any())
+            ->method('getDoctrine')
+            ->will($this->returnValue($doctrine));
+
+        $this->flushAnnotationResolver
+            ->expects($this->any())
+            ->method('getDefaultManager')
+            ->will($this->returnValue('default'));
+
         $this->request = $this
             ->getMockBuilder('Symfony\Component\HttpFoundation\Request')
             ->disableOriginalConstructor()
             ->getMock();
+
+        $this->request->attributes = new ParameterBag();
 
         $this->reflectionMethod = $this
             ->getMockBuilder('ReflectionMethod')
@@ -50,173 +99,173 @@ class FlushAnnotationResolverTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Tests DefaultManager name method
+     *
+     * @param string $annotationManager Manager defined in annotation
+     * @param string $resultManager     Result Manager
+     *
+     * @dataProvider dataManager
      */
-    public function testDefaultManager()
+    public function testManager($annotationManager, $resultManager)
     {
-        $flushAnnotationResolver = $this
-            ->getMockBuilder('Mmoreram\ControllerExtraBundle\Resolver\FlushAnnotationResolver')
+        $doctrine = $this
+            ->getMockBuilder('Symfony\Bridge\Doctrine\ManagerRegistry')
+            ->disableOriginalConstructor()
+            ->setMethods(array(
+                'getManager',
+            ))
+            ->getMock();
+
+        $doctrine
+            ->expects($this->any())
+            ->method('getManager')
+            ->will($this->returnValue($resultManager));
+
+        $this->flushAnnotationResolver
+            ->expects($this->any())
+            ->method('getDoctrine')
+            ->will($this->returnValue($doctrine));
+
+        $annotation = $this
+            ->getMockBuilder('Mmoreram\ControllerExtraBundle\Annotation\Flush')
+            ->disableOriginalConstructor()
+            ->setMethods(array(
+                'getManager',
+            ))
+            ->getMock();
+
+        $annotation
+            ->expects($this->any())
+            ->method('getManager')
+            ->will($this->returnValue($annotationManager));
+
+        $this->flushAnnotationResolver->evaluateAnnotation($this->request, $annotation, $this->reflectionMethod);
+    }
+
+    /**
+     * Data for testManager
+     *
+     * @return array data
+     */
+    public function dataManager()
+    {
+        return array(
+
+            array(null, 'default'),
+            array(false, 'default'),
+            array('', 'default'),
+            array('main', 'main'),
+            array('default', 'default')
+        );
+    }
+
+    /**
+     * Tests entity definition.
+     *
+     * Given every possible possibility, test how this resolver uses defined
+     * annotation data
+     *
+     * @param array $entities          Entities
+     * @param array $requestAttributes Request attributes
+     * @param array $flushedEntities   Flushed entities
+     *
+     * @dataProvider dataEntities
+     */
+    public function testEntities($entities, $requestAttributes, $flushedEntities)
+    {
+
+        $annotation = $this
+            ->getMockBuilder('Mmoreram\ControllerExtraBundle\Annotation\Flush')
+            ->disableOriginalConstructor()
+            ->setMethods(array(
+                'getEntity',
+            ))
+            ->getMock();
+
+        $annotation
+            ->expects($this->once())
+            ->method('getEntity')
+            ->will($this->returnValue($entities));
+
+        $this->request->attributes = new ParameterBag($requestAttributes);
+
+        $this->flushAnnotationResolver->evaluateAnnotation($this->request, $annotation, $this->reflectionMethod);
+        $this->assertEquals($flushedEntities, $this->flushAnnotationResolver->getEntities());
+    }
+
+    /**
+     * Data provider for testEntities method
+     *
+     * @return array data
+     */
+    public function dataEntities()
+    {
+        return array(
+
+            array(
+                null, [], null,
+            ),
+            array(
+                'entity',
+                ['entity' => 'entity_value'],
+                new ArrayCollection(['entity_value']),
+            ),
+            array(
+                ['entity'],
+                ['entity' => 'entity_value'],
+                new ArrayCollection(['entity_value']),
+            ),
+            array(
+                ['entity'],
+                [],
+                null,
+            ),
+            array(
+                ['entity', 'entity2'],
+                ['entity2' => 'entity2_value'],
+                new ArrayCollection(['entity2_value']),
+            ),
+        );
+    }
+
+    /**
+     * Tests Annotation type
+     *
+     * @param string  $annotationNamespace Annotation namespace
+     * @param boolean $mustFlush           Must flush
+     *
+     * @dataProvider dataAnnotationNamespace
+     */
+    public function testAnnotationNamespace($annotationNamespace, $mustFlush)
+    {
+        $annotation = $this
+            ->getMockBuilder($annotationNamespace)
             ->disableOriginalConstructor()
             ->setMethods(null)
             ->getMock();
 
-        $defaultManager = 'default';
-        $this->assertInstanceOf('Mmoreram\ControllerExtraBundle\Resolver\FlushAnnotationResolver', $flushAnnotationResolver->setDefaultManager($defaultManager));
-        $this->assertEquals($defaultManager, $flushAnnotationResolver->getDefaultManager());
+        $this->flushAnnotationResolver->evaluateAnnotation($this->request, $annotation, $this->reflectionMethod);
+        $this->assertEquals($mustFlush, $this->flushAnnotationResolver->getMustFlush());
     }
 
     /**
-     * Tests evaluateAnnotation method
+     * Data for testAnnotationNamespace
      *
-     * This case considers that Annotation is a Flush annotation and no manager is defined in it
+     * @return array data
      */
-    public function testEvaluateAnnotationFlushAnnotationDefaultManager()
+    public function dataAnnotationNamespace()
     {
-        $flushAnnotationResolver = $this
-            ->getMockBuilder('Mmoreram\ControllerExtraBundle\Resolver\FlushAnnotationResolver')
-            ->disableOriginalConstructor()
-            ->setMethods(array(
-                'getDoctrine',
-                'getDefaultManager',
-            ))
-            ->getMock();
+        return array(
 
-        $annotation = $this
-            ->getMockBuilder('Mmoreram\ControllerExtraBundle\Annotation\Flush')
-            ->disableOriginalConstructor()
-            ->setMethods(array(
-                'getManager',
-            ))
-            ->getMock();
-
-        $annotation
-            ->expects($this->once())
-            ->method('getManager')
-            ->will($this->returnValue(null));
-
-        $manager = $this
-            ->getMockBuilder('Doctrine\ORM\EntityManager')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $doctrine = $this
-            ->getMockBuilder('Symfony\Bridge\Doctrine\ManagerRegistry')
-            ->disableOriginalConstructor()
-            ->setMethods(array(
-                'getManager',
-            ))
-            ->getMock();
-
-        $doctrine
-            ->expects($this->once())
-            ->method('getManager')
-            ->will($this->returnValue($manager));
-
-        $flushAnnotationResolver
-            ->expects($this->once())
-            ->method('getDoctrine')
-            ->will($this->returnValue($doctrine));
-
-        $flushAnnotationResolver
-            ->expects($this->once())
-            ->method('getDefaultManager')
-            ->will($this->returnValue('default'));
-
-        $flushAnnotationResolver->evaluateAnnotation($this->request, $annotation, $this->reflectionMethod);
-
-        $this->assertTrue($flushAnnotationResolver->getMustFlush());
-        $this->assertEquals($flushAnnotationResolver->getManager(), $manager);
+            array('Mmoreram\ControllerExtraBundle\Annotation\Flush', true),
+            array('Mmoreram\ControllerExtraBundle\Annotation\Log', false),
+            array('Mmoreram\ControllerExtraBundle\Annotation\Form', false),
+            array('Mmoreram\ControllerExtraBundle\Annotation\Entity', false),
+        );
     }
 
     /**
-     * Tests evaluateAnnotation method
-     *
-     * This case considers that Annotation is a Flush annotation and specific annotation manager
+     * onKernelResponse method
      */
-    public function testEvaluateAnnotationFlushAnnotationSpecificManager()
-    {
-        $flushAnnotationResolver = $this
-            ->getMockBuilder('Mmoreram\ControllerExtraBundle\Resolver\FlushAnnotationResolver')
-            ->disableOriginalConstructor()
-            ->setMethods(array(
-                'getDoctrine',
-            ))
-            ->getMock();
-
-        $annotation = $this
-            ->getMockBuilder('Mmoreram\ControllerExtraBundle\Annotation\Flush')
-            ->disableOriginalConstructor()
-            ->setMethods(array(
-                'getManager',
-            ))
-            ->getMock();
-
-        $annotation
-            ->expects($this->exactly(2))
-            ->method('getManager')
-            ->will($this->returnValue('default'));
-
-        $manager = $this
-            ->getMockBuilder('Doctrine\ORM\EntityManager')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $doctrine = $this
-            ->getMockBuilder('Symfony\Bridge\Doctrine\ManagerRegistry')
-            ->disableOriginalConstructor()
-            ->setMethods(array(
-                'getManager',
-            ))
-            ->getMock();
-
-        $doctrine
-            ->expects($this->once())
-            ->method('getManager')
-            ->will($this->returnValue($manager));
-
-        $flushAnnotationResolver
-            ->expects($this->once())
-            ->method('getDoctrine')
-            ->will($this->returnValue($doctrine));
-
-        $flushAnnotationResolver
-            ->expects($this->any())
-            ->method('getDefaultManager');
-
-        $flushAnnotationResolver->evaluateAnnotation($this->request, $annotation, $this->reflectionMethod);
-
-        $this->assertTrue($flushAnnotationResolver->getMustFlush());
-        $this->assertEquals($flushAnnotationResolver->getManager(), $manager);
-    }
-
-    /**
-     * Tests evaluateAnnotation method
-     *
-     * This case considers that Annotation is not a Flush annotation
-     */
-    public function testEvaluateAnnotationWrongAnnotation()
-    {
-        $flushAnnotationResolver = $this
-            ->getMockBuilder('Mmoreram\ControllerExtraBundle\Resolver\FlushAnnotationResolver')
-            ->disableOriginalConstructor()
-            ->setMethods(array(
-                'getDoctrine',
-            ))
-            ->getMock();
-
-        $annotation = $this
-            ->getMockBuilder('Mmoreram\ControllerExtraBundle\Annotation\Abstracts\Annotation')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $flushAnnotationResolver
-            ->expects($this->any())
-            ->method('getDoctrine');
-
-        $flushAnnotationResolver->evaluateAnnotation($this->request, $annotation, $this->reflectionMethod);
-
-        $this->assertFalse($flushAnnotationResolver->getMustFlush());
-        $this->assertNull($flushAnnotationResolver->getManager());
-    }
 
     /**
      * Tests onKernelResponse method

--- a/Tests/Resolver/LogAnnotationResolverTest.php
+++ b/Tests/Resolver/LogAnnotationResolverTest.php
@@ -74,7 +74,10 @@ class LogAnnotationResolverTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $defaultLevel = 'error';
-        $this->assertInstanceOf('Mmoreram\ControllerExtraBundle\Resolver\LogAnnotationResolver', $logAnnotationResolver->setDefaultLevel($defaultLevel));
+        $this->assertInstanceOf(
+            'Mmoreram\ControllerExtraBundle\Resolver\LogAnnotationResolver',
+            $logAnnotationResolver->setDefaultLevel($defaultLevel)
+        );
         $this->assertEquals($defaultLevel, $logAnnotationResolver->getDefaultLevel());
     }
 
@@ -90,7 +93,10 @@ class LogAnnotationResolverTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $defaultExecute = AnnotationLog::EXEC_POST;
-        $this->assertInstanceOf('Mmoreram\ControllerExtraBundle\Resolver\LogAnnotationResolver', $logAnnotationResolver->setDefaultExecute($defaultExecute));
+        $this->assertInstanceOf(
+            'Mmoreram\ControllerExtraBundle\Resolver\LogAnnotationResolver',
+            $logAnnotationResolver->setDefaultExecute($defaultExecute)
+        );
         $this->assertEquals($defaultExecute, $logAnnotationResolver->getDefaultExecute());
     }
 
@@ -124,6 +130,10 @@ class LogAnnotationResolverTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Tests level setting in evaluateAnnotation method
+     *
+     * @param string $defaultLevel Default level
+     * @param string $level        Level
+     * @param string $resultLevel  Result level
      *
      * @dataProvider dataEvaluateAnnotationLevel
      */
@@ -169,6 +179,10 @@ class LogAnnotationResolverTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Tests execute setting in evaluateAnnotation method
+     *
+     * @param string $defaultExecute Default execute
+     * @param string $execute        Execute
+     * @param string $resultExecute  Result execute
      *
      * @dataProvider dataEvaluateAnnotationExecute
      */
@@ -227,7 +241,11 @@ class LogAnnotationResolverTest extends \PHPUnit_Framework_TestCase
     /**
      * Tests evaluateAnnotation method with a both execution
      *
-     * This case considers that Annotation is a Flush annotation and no manager is defined in it
+     * This case considers that Annotation is a Flush annotation and no manager
+     * is defined in it
+     *
+     * @param string  $execute            Execute
+     * @param boolean $logMessageIsCalled Log message is called
      *
      * @dataProvider dataEvaluateAnnotation
      */
@@ -307,6 +325,10 @@ class LogAnnotationResolverTest extends \PHPUnit_Framework_TestCase
      * Tests onKernelResponse with Exec both
      *
      * This case is with mustLog true
+     *
+     * @param string  $execute            Execute
+     * @param boolean $mustLog            Must log
+     * @param boolean $logMessageIsCalled Log message is called
      *
      * @dataProvider dataOnKernelResponse
      */
@@ -393,6 +415,51 @@ class LogAnnotationResolverTest extends \PHPUnit_Framework_TestCase
             array(AnnotationLog::EXEC_BOTH, false, false),
             array(AnnotationLog::EXEC_POST, true, true),
             array(AnnotationLog::EXEC_POST, false, false),
+        );
+    }
+
+    /**
+     * Tests Annotation type
+     *
+     * @param string  $annotationNamespace Annotation namespace
+     * @param integer $times               Times getClass will be called
+     *
+     * @dataProvider dataAnnotationNamespace
+     */
+    public function testAnnotationNamespace($annotationNamespace, $times)
+    {
+        $logAnnotationResolver = $this
+            ->getMockBuilder('Mmoreram\ControllerExtraBundle\Resolver\LogAnnotationResolver')
+            ->disableOriginalConstructor()
+            ->setMethods(null)
+            ->getMock();
+
+        $annotation = $this
+            ->getMockBuilder($annotationNamespace)
+            ->disableOriginalConstructor()
+            ->setMethods(array('getLevel'))
+            ->getMock();
+
+        $annotation
+            ->expects($this->exactly($times))
+            ->method('getLevel');
+
+        $logAnnotationResolver->evaluateAnnotation($this->request, $annotation, $this->reflectionMethod);
+    }
+
+    /**
+     * Data for testAnnotationNamespace
+     *
+     * @return array data
+     */
+    public function dataAnnotationNamespace()
+    {
+        return array(
+
+            array('Mmoreram\ControllerExtraBundle\Annotation\Log', 1),
+            array('Mmoreram\ControllerExtraBundle\Annotation\Entity', 0),
+            array('Mmoreram\ControllerExtraBundle\Annotation\Flush', 0),
+            array('Mmoreram\ControllerExtraBundle\Annotation\Form', 0),
         );
     }
 }


### PR DESCRIPTION
- Changes in @Entity
  - Entity can be persisted.
  - default_manager can be overwritten in bundle parameters
  - manager can be defined in annotation
  - default_persist can be overwritten in bundle parameters
  - persist can be defined in annotation
  - Tested
- Change in @Flush
  - entity can be defined in annotation
  - if empty, flushes all
  - if single value, flushes single entity
  - if array, flushes all entities in array
  - Tested
- Updated readme
- Some funcional tests. Just entity one
