### PR TITLE
Parameter provider should access current request

### DIFF
--- a/Provider/RequestParameterProvider.php
+++ b/Provider/RequestParameterProvider.php
@@ -35,7 +35,7 @@ class RequestParameterProvider
      */
     public function __construct(RequestStack $requestStack)
     {
-        $this->request = $requestStack->getMasterRequest();
+        $this->request = $requestStack->getCurrentRequest();
     }
 
     /**


### PR DESCRIPTION
RequestParamaterProvider service should access current request and not
master request. Parameters of interest should be passed to subrequests
directly.
