### PR TITLE
Fix dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,17 +16,21 @@
         "doctrine/common": "~2.3",
         "symfony/config": "~2.3",
         "symfony/http-kernel": "~2.3",
-        "symfony/http-foundation": "~2.3",
+        "symfony/http-foundation": "~2.4",
         "symfony/dependency-injection": "~2.3"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "~1.2",
-        "symfony/framework-bundle": "~2.3",
+        "symfony/framework-bundle": "~2.4",
         "symfony/finder": "~2.3",
         "symfony/validator": "~2.3",
         "symfony/browser-kit": "~2.3",
         "phpunit/phpunit": ">=3.7",
-        "mmoreram/php-formatter": "~1.0"
+        "mmoreram/php-formatter": "~1.0",
+        "symfony/monolog-bundle": "~2.3",
+        "doctrine/orm": "~2.3",
+        "symfony/form": "~2.3",
+        "pagerfanta/pagerfanta": "~1.0"
     },
     "suggest": {
         "symfony/monolog-bundle": "to use the @Log annotation",


### PR DESCRIPTION
Using `--prefer-lowest` in composer, I found some problems in dependencies.
- In prod
    - Needs `symfony/http-foundation: ~2.4` as it uses `RequestStack`.
- In tests
    - Needs `symfony/framework-bundle` for `request_stack` service definition.
    - Needs suggested dependencies for testing.
    - Needs `doctrine/orm: ~2.3` as this is not a dependency of `doctrine/doctrine-bundle` (don't ask me why)
