### PR TITLE
Json response when exception is launched from annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1415,6 +1415,9 @@ We'll receive this response
 
 ```
 
+> If the exception is being launched on an annotation (e.g. Entity annotation) remember to add the JsonResponse
+> annotation at the beginning or at least before any annotation that could cause an exception
+
 > If multiple @Mmoreram\JsonResponse are defined in same action, last instance 
 > will overwrite previous. Anyway just one instance should be defined.
 

--- a/Resources/config/resolver_json_response.yml
+++ b/Resources/config/resolver_json_response.yml
@@ -19,3 +19,4 @@ services:
         tags:
             - { name: controller_extra.annotation }
             - { name: kernel.event_listener, event: kernel.view, method: onKernelView, priority: -128 }
+            - { name: kernel.event_listener, event: kernel.exception, method: onKernelException, priority: -128 }

--- a/Tests/FakeBundle/Controller/FakeController.php
+++ b/Tests/FakeBundle/Controller/FakeController.php
@@ -206,6 +206,27 @@ class FakeController extends Controller
     }
 
     /**
+     * Public method
+     *
+     * @\Mmoreram\ControllerExtraBundle\Annotation\JsonResponse()
+     * @\Mmoreram\ControllerExtraBundle\Annotation\Entity(
+     *      name = "entity",
+     *      class = "FakeBundle:Fake",
+     *      mapping = {
+     *          "id" = "~id~",
+     *          "field" = "value",
+     *      },
+     *      notFoundException = {
+     *          "exception" = "Symfony\Component\HttpKernel\Exception\NotFoundHttpException",
+     *          "message" = "Exception launched from an annotation"
+     *      }
+     * )
+     */
+    public function jsonResponseAnnotationExceptionAction(Fake $entity)
+    {
+    }
+
+    /**
      * Public pagination method
      *
      * @\Mmoreram\ControllerExtraBundle\Annotation\Paginator(

--- a/Tests/FakeBundle/Resources/config/routing.yml
+++ b/Tests/FakeBundle/Resources/config/routing.yml
@@ -26,6 +26,10 @@ FakeBundleControllerJsonResponseException:
     pattern: /fake/jsonresponseexception
     defaults: { _controller: FakeBundle:Fake:jsonResponseException }
 
+FakeBundleControllerJsonResponseAnnotationException:
+    pattern: /fake/jsonresponseannotationexception
+    defaults: { _controller: FakeBundle:Fake:jsonResponseAnnotationException }
+
 FakeBundleControllerJsonResponseHttpException:
     pattern: /fake/jsonresponsehttpexception
     defaults: { _controller: FakeBundle:Fake:jsonResponseHttpException }

--- a/Tests/Functional/Resolver/JsonResponseAnnotationResolverTest.php
+++ b/Tests/Functional/Resolver/JsonResponseAnnotationResolverTest.php
@@ -65,12 +65,40 @@ class JsonResponseAnnotationResolverTest extends AbstractWebTestCase
     {
         $this->client->request('GET', '/fake/jsonresponsehttpexception');
 
+        $response = $this
+            ->client
+            ->getResponse();
+
         $this->assertEquals(
             '{"message":"Not found exception"}',
-            $this
-                ->client
-                ->getResponse()
-                ->getContent()
+            $response->getContent()
+        );
+
+        $this->assertEquals(
+            '404',
+            $response->getStatusCode()
+        );
+    }
+
+    /**
+     * Test that an exception is laucned from an annotation
+     */
+    public function testAnnotationRequestWhenExceptionIsLaunchedByAnnotation()
+    {
+        $this->client->request('GET', '/fake/jsonresponseannotationexception');
+
+        $response = $this
+            ->client
+            ->getResponse();
+
+        $this->assertEquals(
+            '{"message":"Exception launched from an annotation"}',
+            $response->getContent()
+        );
+
+        $this->assertEquals(
+            '404',
+            $response->getStatusCode()
         );
     }
 }


### PR DESCRIPTION
Now when we launch an exception from the annotations if the JsonResponse has been evaluated the exception is also converted to a JsonResponse