### PR TITLE
Support `FormAnnotation` with no form parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,20 @@
 language: php
 
+env:
+    COMPOSER_OPTIONS=""
+
 php:
     - 5.3
     - 5.4
     - 5.5
     - 5.6
-    - hhvm-nightly
+    - hhvm
+    - 7.0
 
 matrix:
-    allow_failures:
-        - php: hhvm-nightly
+    include:
+        - php: 5.3
+          env: COMPOSER_OPTIONS="--prefer-lowest"
 
 env:
     - SYMFONY_VERSION="~2.3"
@@ -21,7 +26,7 @@ before_install:
     - composer require --no-update white-october/pagerfanta-bundle:~1.0
 
 install:
-    - composer install --prefer-source --no-interaction
+    - composer update --prefer-source --no-interaction ${COMPOSER_OPTIONS}
 
 script:
     - phpunit -c phpunit.xml.dist

--- a/Resolver/Abstracts/AbstractAnnotationResolver.php
+++ b/Resolver/Abstracts/AbstractAnnotationResolver.php
@@ -26,10 +26,11 @@ class AbstractAnnotationResolver
      *
      * @param ReflectionMethod $method        Method
      * @param string           $parameterName Parameter name
+     * @param string|null      $default       Default type if not defined
      *
-     * @return string Parameter type
+     * @return string|null Parameter type
      */
-    public function getParameterType(ReflectionMethod $method, $parameterName)
+    public function getParameterType(ReflectionMethod $method, $parameterName, $default = null)
     {
         /**
          * Method parameters load.
@@ -48,11 +49,14 @@ class AbstractAnnotationResolver
         /**
          * Get parameter class for TypeHinting
          *
-         * @var ReflectionParameter $parameter
+         * @var ReflectionParameter[] $parametersIndexed
          */
-        $parameter = $parametersIndexed[$parameterName];
+        if (!isset($parametersIndexed[$parameterName])) {
 
-        return $parameter
+            return $default;
+        }
+
+        return $parametersIndexed[$parameterName]
             ->getClass()
             ->getName();
     }

--- a/Resolver/Abstracts/AbstractAnnotationResolver.php
+++ b/Resolver/Abstracts/AbstractAnnotationResolver.php
@@ -14,7 +14,6 @@
 namespace Mmoreram\ControllerExtraBundle\Resolver\Abstracts;
 
 use ReflectionMethod;
-use ReflectionParameter;
 
 /**
  * Class AbstractAnnotationResolver
@@ -32,32 +31,18 @@ class AbstractAnnotationResolver
      */
     public function getParameterType(ReflectionMethod $method, $parameterName, $default = null)
     {
-        /**
-         * Method parameters load.
-         *
-         * A hash is created to access to all needed parameters
-         * with cost O(1)
-         */
         $parameters = $method->getParameters();
-        $parametersIndexed = array();
 
         foreach ($parameters as $parameter) {
+            if ($parameter->getName() === $parameterName) {
+                $class = $parameter->getClass();
 
-            $parametersIndexed[$parameter->getName()] = $parameter;
+                return $class
+                    ? $class->getName()
+                    : $default;
+            }
         }
 
-        /**
-         * Get parameter class for TypeHinting
-         *
-         * @var ReflectionParameter[] $parametersIndexed
-         */
-        if (!isset($parametersIndexed[$parameterName])) {
-
-            return $default;
-        }
-
-        return $parametersIndexed[$parameterName]
-            ->getClass()
-            ->getName();
+        return $default;
     }
 }

--- a/Resolver/EntityAnnotationResolver.php
+++ b/Resolver/EntityAnnotationResolver.php
@@ -220,7 +220,8 @@ class EntityAnnotationResolver implements AnnotationResolverInterface
 
                 $notFoundException = $annotation->getNotFoundException();
                 if (!empty($notFoundException)) {
-                    throw new $notFoundException['exception'()]($notFoundException['message']);
+                    $exceptionClassName = $notFoundException['exception'];
+                    throw new $exceptionClassName($notFoundException['message']);
                 }
 
                 throw new EntityNotFoundException(

--- a/Resolver/EntityAnnotationResolver.php
+++ b/Resolver/EntityAnnotationResolver.php
@@ -220,7 +220,7 @@ class EntityAnnotationResolver implements AnnotationResolverInterface
 
                 $notFoundException = $annotation->getNotFoundException();
                 if (!empty($notFoundException)) {
-                    throw new $notFoundException['exception']($notFoundException['message']);
+                    throw new $notFoundException['exception'()]($notFoundException['message']);
                 }
 
                 throw new EntityNotFoundException(

--- a/Resolver/FormAnnotationResolver.php
+++ b/Resolver/FormAnnotationResolver.php
@@ -109,7 +109,8 @@ class FormAnnotationResolver extends AbstractAnnotationResolver implements Annot
             $parameterName = $annotation->getName() ?: $this->defaultName;
             $parameterClass = $this->getParameterType(
                 $method,
-                $parameterName
+                $parameterName,
+                'Symfony\\Component\\Form\\FormInterface'
             );
 
             /**

--- a/Tests/FakeBundle/Controller/FakeController.php
+++ b/Tests/FakeBundle/Controller/FakeController.php
@@ -17,6 +17,9 @@ use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Pagerfanta\Pagerfanta;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -697,5 +700,34 @@ class FakeController extends Controller
         return array(
             'param' => $param
         );
+    }
+
+    /**
+     * Form methods
+     *
+     * @\Mmoreram\ControllerExtraBundle\Annotation\Form(
+     *      class = "Mmoreram\ControllerExtraBundle\Tests\FakeBundle\Form\Type\FakeType",
+     *      name = "form1"
+     * )
+     * @\Mmoreram\ControllerExtraBundle\Annotation\Form(
+     *      class = "Mmoreram\ControllerExtraBundle\Tests\FakeBundle\Form\Type\FakeType",
+     *      name = "form2"
+     * )
+     * @\Mmoreram\ControllerExtraBundle\Annotation\Form(
+     *      class = "Mmoreram\ControllerExtraBundle\Tests\FakeBundle\Form\Type\FakeType",
+     *      name = "form3"
+     * )
+     * @\Mmoreram\ControllerExtraBundle\Annotation\Form(
+     *      class = "Mmoreram\ControllerExtraBundle\Tests\FakeBundle\Form\Type\FakeType",
+     *      name = "form4"
+     * )
+     */
+    public function formAction(
+        AbstractType $form1,
+        FormInterface $form2,
+        FormView $form3
+    )
+    {
+        return new Response();
     }
 }

--- a/Tests/FakeBundle/Form/Type/FakeType.php
+++ b/Tests/FakeBundle/Form/Type/FakeType.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the ControllerExtraBundle for Symfony2.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+namespace Mmoreram\ControllerExtraBundle\Tests\FakeBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+/**
+ * Class FakeType
+ */
+class FakeType extends AbstractType
+{
+    /**
+     * Default form options
+     *
+     * @param OptionsResolverInterface $resolver
+     *
+     * @return array With the options
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults([
+            'data_class' => 'Mmoreram\ControllerExtraBundle\Tests\FakeBundle\Entity\Fake',
+        ]);
+    }
+    /**
+     * Buildform function
+     *
+     * @param FormBuilderInterface $builder the formBuilder
+     * @param array                $options the options for this form
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('field', 'text');
+    }
+
+    /**
+     * Return unique name for this form
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'fake_form_type';
+    }
+}

--- a/Tests/FakeBundle/Form/Type/FakeType.php
+++ b/Tests/FakeBundle/Form/Type/FakeType.php
@@ -31,10 +31,11 @@ class FakeType extends AbstractType
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        $resolver->setDefaults([
+        $resolver->setDefaults(array(
             'data_class' => 'Mmoreram\ControllerExtraBundle\Tests\FakeBundle\Entity\Fake',
-        ]);
+        ));
     }
+
     /**
      * Buildform function
      *

--- a/Tests/FakeBundle/Resources/config/routing.yml
+++ b/Tests/FakeBundle/Resources/config/routing.yml
@@ -98,3 +98,6 @@ FakeBundleControllerGetPostParameterDeep:
     pattern: /fake/getpostparameterdeep
     defaults: { _controller: FakeBundle:Fake:postParameterDeep }
 
+FakeBundleControllerForm:
+    pattern: /fake/form
+    defaults: { _controller: FakeBundle:Fake:form }

--- a/Tests/Functional/Resolver/FormAnnotationResolverTest.php
+++ b/Tests/Functional/Resolver/FormAnnotationResolverTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the ControllerExtraBundle for Symfony2.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+namespace Mmoreram\ControllerExtraBundle\Tests\Functional\Resolver;
+
+use Mmoreram\ControllerExtraBundle\Tests\Functional\AbstractWebTestCase;
+
+/**
+ * Class FormAnnotationResolverTest
+ */
+class FormAnnotationResolverTest extends AbstractWebTestCase
+{
+    /**
+     * testAnnotation
+     */
+    public function testAnnotation()
+    {
+        $this
+            ->client
+            ->request('GET', '/fake/form');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "~1.2",
+        "doctrine/annotations": "~1.0, >=1.2",
         "symfony/framework-bundle": "~2.4",
         "symfony/finder": "~2.3",
         "symfony/validator": "~2.3",


### PR DESCRIPTION
Fix #42

- Add `$default` result to `AbstractAnnotationResolver::getParameterType`.
- Remove unnecessary hash creation in method.