### PR TITLE
Add limit per page to PaginatorAttributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,6 +643,7 @@ instance with some interesting information about your pagination.
 * totalElements : Total elements given your criteria. If none criteria is
 defined in your configuration, this value will show all elements of a certain entity.
 * totalPages : Total pages you can fetch given a criteria.
+* limitPerPage: Maximum number of elements in each page.
 
 To inject this object you need to define the "attributes" annotation field with
 the method parameter name.
@@ -668,6 +669,7 @@ public function indexAction(
     $currentPage = $paginatorAttributes->getCurrentPage();
     $totalElements = $paginatorAttributes->getTotalElements();
     $totalPages = $paginatorAttributes->getTotalPages();
+    $limitPerPage = $paginatorAttributes->getLimitPerPage();
 
 }
 ```

--- a/Resolver/PaginatorAnnotationResolver.php
+++ b/Resolver/PaginatorAnnotationResolver.php
@@ -283,6 +283,7 @@ class PaginatorAnnotationResolver extends AbstractAnnotationResolver implements 
 
             $paginatorAttributes
                 ->setCurrentPage($page)
+                ->setLimitPerPage($limitPerPage)
                 ->setTotalElements($total)
                 ->setTotalPages(ceil($total / $limitPerPage));
 

--- a/ValueObject/PaginatorAttributes.php
+++ b/ValueObject/PaginatorAttributes.php
@@ -40,6 +40,13 @@ class PaginatorAttributes
     protected $currentPage;
 
     /**
+     * @var integer
+     *
+     * number of elements per page
+     */
+    protected $limitPerPage;
+
+    /**
      * Sets TotalElements
      *
      * @param int $totalElements TotalElements
@@ -109,5 +116,29 @@ class PaginatorAttributes
     public function getCurrentPage()
     {
         return $this->currentPage;
+    }
+
+    /**
+     * Sets LimitPerPage
+     *
+     * @param int $limitPerPage
+     *
+     * @return PaginatorAttributes Self object
+     */
+    public function setLimitPerPage($limitPerPage)
+    {
+        $this->limitPerPage = $limitPerPage;
+
+        return $this;
+    }
+
+    /**
+     * Get LimitPerPage
+     *
+     * @return int LimitPerPage
+     */
+    public function getLimitPerPage()
+    {
+        return $this->limitPerPage;
     }
 }


### PR DESCRIPTION
The class `PaginatorAttributes` is missing the number of elements per page.