### PR TITLE
make it more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,11 +372,11 @@ You can refer to an existing Request attribute using `~value~` format, to any
 /**
  * Simple controller method
  *
- * This Controller matches pattern /myroute/paginate/{pag}
+ * This Controller matches pattern /myroute/paginate/{foo}
  *
  * @PaginatorAnnotation(
  *      class = "MmoreramCustomBundle:User",
- *      page = "~pag~"
+ *      page = "~foo~"
  * )
  */
 public function indexAction(Paginator $paginator)


### PR DESCRIPTION
i thought it was a type, so foo is better, that the users will not missunderstand the example i think!