### PR TITLE
make it more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,11 +422,11 @@ You can refer to an existing Request attribute using `~value~` format, to any
 /**
  * Simple controller method
  *
- * This Controller matches pattern /myroute/paginate/{pag}/{limit}
+ * This Controller matches pattern /myroute/paginate/{foo}/{limit}
  *
  * @PaginatorAnnotation(
  *      class = "MmoreramCustomBundle:User",
- *      page = "~pag~",
+ *      page = "~foo~",
  *      limit = "~limit~"
  * )
  */


### PR DESCRIPTION
i thought it was a type, so foo is better, that the users will not missunderstand the example i think!