### PR TITLE
Do not try to get collector if services does not exist

### DIFF
--- a/CompilerPass/PaginatorCompilerPass.php
+++ b/CompilerPass/PaginatorCompilerPass.php
@@ -29,6 +29,10 @@ class PaginatorCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
+        if (!$container->hasDefinition('mmoreram.controllerextra.collector.paginator_evaluator_collector')) {
+            return;
+        }
+
         /**
          * We get our collector
          */


### PR DESCRIPTION
When you deactivate the paginator in the config, an error `The service definition "mmoreram.controllerextra.collector.paginator_evaluator_collector" does not exist.` is thrown. This PR fixes this, by first checking if the service definition exists.

Steps to reproduce:

1. Use the following config:

    ```yml
    controller_extra:
        paginator:
            active: false
    ```

2. Run `app/console cache:clear`