### PR TITLE
travis: bump min version to PHP 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ env:
     COMPOSER_OPTIONS=""
 
 php:
-    - 5.3
     - 5.4
     - 5.5
     - 5.6
@@ -15,7 +14,7 @@ php:
 
 matrix:
     include:
-        - php: 5.3
+        - php: 5.4
           env: COMPOSER_OPTIONS="--prefer-lowest"
 
 env:


### PR DESCRIPTION
Due to PHP 5.4 requirement of mmoreram/php-formatter