### PR TITLE
Always try form registry first

### DIFF
--- a/Resolver/FormAnnotationResolver.php
+++ b/Resolver/FormAnnotationResolver.php
@@ -94,9 +94,7 @@ class FormAnnotationResolver extends AbstractAnnotationResolver implements Annot
             /**
              * Get FormType object given a service name.
              */
-            $type = class_exists($annotationValue)
-                ? new $annotationValue()
-                : $this
+            $type = $this
                     ->formRegistry
                     ->getType($annotationValue)
                     ->getInnerType();

--- a/Tests/UnitTest/Resolver/FormAnnotationResolverTest.php
+++ b/Tests/UnitTest/Resolver/FormAnnotationResolverTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of the ControllerExtraBundle for Symfony2.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+namespace Mmoreram\ControllerExtraBundle\Tests\UnitTest\Resolver;
+
+use Mmoreram\ControllerExtraBundle\Annotation\Form;
+use Mmoreram\ControllerExtraBundle\Resolver\FormAnnotationResolver;
+use Mmoreram\ControllerExtraBundle\Tests\FakeBundle\Form\Type\FakeType;
+use PHPUnit_Framework_TestCase;
+use ReflectionMethod;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormRegistryInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+use Mmoreram\ControllerExtraBundle\Annotation\Abstracts\Annotation;
+
+/**
+ * Tests FormAnnotationResolver class.
+ */
+class FormAnnotationResolverTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var FormAnnotationResolver
+     *
+     * Form Annotation Resolver
+     */
+    private $formAnnotationResolver;
+
+    /**
+     * @var Request
+     *
+     * Request
+     */
+    private $request;
+
+    /**
+     * @var ReflectionMethod
+     *
+     * Reflection Method
+     */
+    private $reflectionMethod;
+
+    /**
+     * @var Annotation
+     *
+     * Annotation
+     */
+    private $annotation;
+
+    /**
+     * @var FormRegistryInterface
+     */
+    private $formRegistry;
+
+    /**
+     * @var FormFactoryInterface
+     */
+    private $formFactory;
+
+    /**
+     * Setup method.
+     */
+    public function setUp()
+    {
+        $this->formRegistry = $this->getMock('Symfony\Component\Form\FormRegistryInterface');
+        $this->formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+
+        $requestParameterProvider = $this
+            ->getMockBuilder('Mmoreram\ControllerExtraBundle\Provider\RequestParameterProvider')
+            ->disableOriginalConstructor()
+            ->setMethods([])
+            ->getMock();
+
+        $requestParameterProvider
+            ->expects($this->any())
+            ->method('getParameterValue')
+            ->will($this->returnValue(''));
+
+        $this->formAnnotationResolver = new FormAnnotationResolver(
+            $this->formRegistry,
+            $this->formFactory,
+            'form'
+        );
+
+        $this->request = new Request();
+
+        $this->annotation = $this
+            ->getMockBuilder('Mmoreram\ControllerExtraBundle\Annotation\Entity')
+            ->disableOriginalConstructor()
+            ->setMethods([
+                'getClass',
+                'getName',
+            ])
+            ->getMock();
+
+        $this->reflectionMethod = new ReflectionMethod(
+            'Mmoreram\ControllerExtraBundle\Tests\FakeBundle\Controller\FakeController',
+            'formAction'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function testFQDNUsesFormRegistry()
+    {
+        $resolvedFormTypeInterface = $this->getMock('Symfony\Component\Form\ResolvedFormTypeInterface');
+        $resolvedFormTypeInterface->method('getInnerType')->willReturn(new FakeType());
+
+        $class = 'Mmoreram\ControllerExtraBundle\Tests\FakeBundle\Form\Type\FakeType';
+        $annotation = new Form([
+            'class' => $class,
+        ]);
+
+        $this
+            ->formRegistry
+            ->expects($this->once())
+            ->method('getType')
+            ->with($class)
+            ->will($this->returnValue($resolvedFormTypeInterface));
+
+        $this->formAnnotationResolver->evaluateAnnotation($this->request, $annotation, $this->reflectionMethod);
+    }
+}


### PR DESCRIPTION
In 2.8 the `getName` method from the [FormTypeInterface](https://github.com/symfony/symfony/blob/2.8/src/Symfony/Component/Form/FormTypeInterface.php#L106) is deprecated, instead the FQDN should be used. When doing so, the `FormAnnotationResolver` always tries to instantiate the class instead of using the formRegistry.
Since the FormRegistry already handles [this case](https://github.com/symfony/symfony/blob/2.8/src/Symfony/Component/Form/FormRegistry.php#L89-L93) since 2.8, I check the registry if the type exists and get it from the there instead of trying to instantiate it.

This should not break any compatibility.