### PR TITLE
Update annotations_resolver.yml

### DIFF
--- a/Resources/config/annotations_resolver.yml
+++ b/Resources/config/annotations_resolver.yml
@@ -9,4 +9,4 @@ services:
             - "@kernel"
             - "@annotation_reader"
         tags:
-            - { name: kernel.event_listener, event: kernel.controller, method: onKernelController, priority: %controller_extra.resolver_priority% }
+            - { name: kernel.event_listener, event: kernel.controller, method: onKernelController, priority: '%controller_extra.resolver_priority%' }


### PR DESCRIPTION
Not quoting the scalar "%controller_extra.resolver_priority% " starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 in "/var/www/html/vendor/mmoreram/controller-extra-bundle/DependencyInjection/../Resources/config/annotations_resolver.yml" on line 12.