### PR TITLE
Update README: controller_extra.annotation_resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1832,7 +1832,7 @@ services:
     my.bundle.resolver.my_custom_annotation_resolver:
         class: %my.bundle.resolver.my_custom_annotation_resolver.class%
         tags:
-            - { name: controller_extra.annotation }
+            - { name: controller_extra.annotation_resolver }
 ```
 
 ## Registration


### PR DESCRIPTION
I was migrating Symfony from 2 to 3, thus from v1 to v2 of this bundle. I was still relying on the old tag `controller_extra.annotation`, that was changed about a year ago.

I suppose the README needs to be changed as well.